### PR TITLE
Router-chain.git not present

### DIFF
--- a/docs/router-core/routerd.md
+++ b/docs/router-core/routerd.md
@@ -10,6 +10,7 @@ sidebar_position: 2
 To install `routerd` and interact with the Router Core without running a node, run the following commands on your terminal/cmd:
 ```bash
 git clone https://github.com/router-protocol/router-chain.git
+// router-chain.git to be released yet
 cd router-chain
 git checkout dev
 make install


### PR DESCRIPTION
Hey i think there is a mistake unable to install or find the router chain core.

