### PR TITLE
add: pf refund addr

### DIFF
--- a/docs/develop/asset-transfer/nitro/tools/nitro-js-sdk/execute-transaction.md
+++ b/docs/develop/asset-transfer/nitro/tools/nitro-js-sdk/execute-transaction.md
@@ -48,6 +48,7 @@ const main = async () => {
       slippageTolerance: "1",
       senderAddress: evmSigner.address,
       receiverAddress: evmSigner.address,
+      refundAddress: evmSigner.address // (optional) By default equal to `senderAddress` if not provided
     },
     {
       evmSigner,
@@ -89,6 +90,7 @@ const main = async () => {
       slippageTolerance: "1",
       senderAddress: evmSigner.address, // tron address
       receiverAddress: evmSigner.address,
+      refundAddress: evmSigner.address // (optional) By default equal to `senderAddress` if not provided
     },
     {
       evmSigner,
@@ -133,6 +135,7 @@ const main = async () => {
       slippageTolerance: "1",
       senderAddress: "joydeeeep.testnet",
       receiverAddress: "0x40d5250D1ce81fdD1F0E0FB4F471E57AA0c1FaD3",
+      refundAddress: "joydeeeep.testnet" // (optional) By default equal to `senderAddress` if not provided
     },
     {
       nearAccount: nearSigner,

--- a/docs/develop/asset-transfer/nitro/tools/nitro-pathfinder-api/performing-cross-chain-transaction/execute-transaction.md
+++ b/docs/develop/asset-transfer/nitro/tools/nitro-pathfinder-api/performing-cross-chain-transaction/execute-transaction.md
@@ -22,6 +22,7 @@ const getTransaction = async (params, quoteData) => {
             slippageTolerance: 0.5,
             senderAddress: "<sender-address>",
             receiverAddress: "<receiver-address>",
+            refundAddress: "<refundAddress>" // (optional) By default equal to `senderAddress` if not provided
         })
         return res.data;
     } catch (e) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Osmosis - we are happy that you want to help us improve Osmosis and its docs. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Osmosis a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Name the pull request in the form "[ISSUE-XXXX] [component] Title of the pull request", where *XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request improves documation of area A by adding ....*


## Brief change log

*(for example:)*
  - *Added content in page XXX*
  - *Updated cross reference link in YYY*


## Verifying this change

*(Please pick either of the following options)*

This change has been tested locally by rebuilding the doc website and verified content and links are expected

*(or)*

This change has not been tested locally, because (to-be-explained-why...)

