### PR TITLE
update: pf api description

### DIFF
--- a/static/api/PATHFINDER.yaml
+++ b/static/api/PATHFINDER.yaml
@@ -173,7 +173,7 @@ components:
           description: destination token as per request
         source:
           type: object
-          description: In case of source swap. 'tokenAmount' is amount user provides. It contains path details for swap that will be used by dexSpan contract (Nitro's swapper contract). Note - native tokens are represented as its wrapped native in quote as it's used by dexSpan. Actual input token is determined by user request `fromTokenAddress` if to be taken as gas. Currently, final output token as wrapped native is not supported. 
+          description: In case of source swap. 'tokenAmount' is amount user provides. It contains path details for swap that will be used by dexSpan contract (Nitro's swapper contract). Note - native tokens are represented as its wrapped native in quote as it's used by dexSpan. Actual input token is determined by user request `fromTokenAddress` if to be taken as gas.
           required:
             - "chainId"
             - "asset"
@@ -192,6 +192,7 @@ components:
               example: "80001"
             asset:
               type: object
+              description: source input token
               required:
                 - "decimals"
                 - "symbol"
@@ -228,6 +229,7 @@ components:
                   example: false
             stableReserveAsset:
               type: object
+              description: source final swapped token that will be transferred to destination through a 'flowType'.
               required:
                 - "decimals"
                 - "symbol"
@@ -290,7 +292,7 @@ components:
               example: []
         destination:
           type: object
-          description: In case of destination swap. `tokenAmount` is final amount that will be given to user. It contains path details for swap that will be used by dexSpan contract (Nitro's swapper contract).
+          description: In case of destination swap. `tokenAmount` is final amount that will be given to user. It contains path details for swap that will be used by dexSpan contract (Nitro's swapper contract).  Currently, final output token as wrapped native is not supported. 
           required:
             - "chainId"
             - "asset"
@@ -308,6 +310,7 @@ components:
               example: "43113"
             asset:
               type: object
+              destination: 'stableReserveAsset' is swapped to 'asset' if path length > 1 and sent to receiver. Note - final token as wrapped native is not supported currently. User will get native on destination in this case.
               required:
                 - "decimals"
                 - "symbol"
@@ -344,6 +347,7 @@ components:
                   example: false
             stableReserveAsset:
               type: object
+              description: token that initially is transferred on destination.
               required:
                 - "decimals"
                 - "symbol"
@@ -387,6 +391,7 @@ components:
             path:
               type: array
               example: []
+              description: If length of path is greater than 1, then only token is swap from index 0 'stableReserveAsset' to index length-1 'asset' of array using others as intermediate tokens.
             flags:
               type: array
               example: []
@@ -1008,4 +1013,4 @@ components:
               'value': 'gas value',
               'gasPrice': 'gas price',
               'gasLimit': 'estimated gas limit. In case of gaslimit failure we provided some static value according to flowType'
-            description: 'transaction object for a chain. Can be different for different chain types'
+            description: 'transaction object for a chain. Can be different for different chain types.'


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Osmosis - we are happy that you want to help us improve Osmosis and its docs. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Osmosis a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Name the pull request in the form "[ISSUE-XXXX] [component] Title of the pull request", where *XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request improves documation of area A by adding ....*


## Brief change log

*(for example:)*
  - *Added content in page XXX*
  - *Updated cross reference link in YYY*


## Verifying this change

*(Please pick either of the following options)*

This change has been tested locally by rebuilding the doc website and verified content and links are expected

*(or)*

This change has not been tested locally, because (to-be-explained-why...)

